### PR TITLE
fix libmetal 2018.04 license file checksum

### DIFF
--- a/recipes-openamp/libmetal/libmetal_2018.04.bb
+++ b/recipes-openamp/libmetal/libmetal_2018.04.bb
@@ -1,6 +1,6 @@
 SRCBRANCH ?= "master"
-SRCREV = "606c31438025b9fb1515dace1c642d5835d8d33c"
-LIC_FILES_CHKSUM = "file://LICENSE.md;md5=395307789d21fd8945fc1c933cad18b5"
+SRCREV ?= "606c31438025b9fb1515dace1c642d5835d8d33c"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=fe0b8a4beea8f0813b606d15a3df3d3c"
 
 include libmetal.inc
 

--- a/recipes-openamp/open-amp/open-amp_2018.04.bb
+++ b/recipes-openamp/open-amp/open-amp_2018.04.bb
@@ -1,5 +1,5 @@
 SRCBRANCH ?= "master"
-SRCREV = "de361adee09cd31793c60218a0ec49bc307a7410"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=b30cbe0b980e98bfd9759b1e6ba3d107"
+SRCREV ?= "de361adee09cd31793c60218a0ec49bc307a7410"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=a8d8cf662ef6bf9936a1e1413585ecbf"
 
 include open-amp.inc


### PR DESCRIPTION
libmetal_2018.04's license.md file converted SPDX-tag version.
I fixed cheksum value.
