### PR TITLE
Fix PACKAGE_ARCH for use on non-xilinx SOC

### DIFF
--- a/recipes-openamp/libmetal/libmetal.inc
+++ b/recipes-openamp/libmetal/libmetal.inc
@@ -28,7 +28,10 @@ inherit pkgconfig cmake yocto-cmake-translation
 LIBMETAL_MACHINE_versal = "zynqmp"
 LIBMETAL_MACHINE ?= "${@get_cmake_machine(d.getVar('TARGET_OS'), d.getVar('TUNE_ARCH'), d.getVar('SOC_FAMILY'), d)}"
 
-PACKAGE_ARCH = "${SOC_FAMILY_ARCH}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+PACKAGE_ARCH_zynq = "${SOC_FAMILY_ARCH}"
+PACKAGE_ARCH_zynqmp = "${SOC_FAMILY_ARCH}"
+PACKAGE_ARCH_versal = "${SOC_FAMILY_ARCH}"
 
 EXTRA_OECMAKE = " \
 	-DLIB_INSTALL_DIR=${libdir} \

--- a/recipes-openamp/open-amp/open-amp.inc
+++ b/recipes-openamp/open-amp/open-amp.inc
@@ -30,7 +30,10 @@ EXTRA_OECMAKE = " \
 	-DMACHINE=${OPENAMP_MACHINE} \
 	"
 
-PACKAGE_ARCH = "${SOC_FAMILY_ARCH}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+PACKAGE_ARCH_zynq = "${SOC_FAMILY_ARCH}"
+PACKAGE_ARCH_zynqmp = "${SOC_FAMILY_ARCH}"
+PACKAGE_ARCH_versal = "${SOC_FAMILY_ARCH}"
 
 CFLAGS_versal += " -Dversal "
 # OpenAMP apps not ready for Zynq


### PR DESCRIPTION
Don't use vendor specific code like SOC_FAMILY_ARCH in non-bsp layers.