### PR TITLE
Fix generic BSD warnings

### DIFF
--- a/recipes-openamp/libmetal/libmetal.inc
+++ b/recipes-openamp/libmetal/libmetal.inc
@@ -4,7 +4,9 @@ HOMEPAGE = "https://github.com/OpenAMP/libmetal/"
 
 SECTION = "libs"
 
-LICENSE = "BSD"
+# NOTE: some scripts used in patch compliance are Apache-2.0 but these are not
+# used on target nor in normal builds
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=fe0b8a4beea8f0813b606d15a3df3d3c"
 
 REPO ?= "git://github.com/OpenAMP/libmetal.git;protocol=https"

--- a/recipes-openamp/open-amp/open-amp.inc
+++ b/recipes-openamp/open-amp/open-amp.inc
@@ -4,7 +4,8 @@ HOMEPAGE = "https://github.com/OpenAMP/open-amp/"
 
 SECTION = "libs"
 
-LICENSE = "BSD"
+# As of 2022/04/27, the virtio layer is BSD 2 Clause and the rest BSD 3 Clause
+LICENSE = "BSD-3-Clause & BSD-2-Clause"
 LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=a8d8cf662ef6bf9936a1e1413585ecbf"
 
 REPO ?= "git://github.com/OpenAMP/open-amp.git;protocol=https"

--- a/recipes-openamp/rpmsg-examples/rpmsg-echo-test_1.0.bb
+++ b/recipes-openamp/rpmsg-examples/rpmsg-echo-test_1.0.bb
@@ -1,6 +1,6 @@
 SUMMARY = "RPMsg examples: echo test demo"
 
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b30cbe0b980e98bfd9759b1e6ba3d107"
 
 SRC_URI = "\

--- a/recipes-openamp/rpmsg-examples/rpmsg-mat-mul_1.0.bb
+++ b/recipes-openamp/rpmsg-examples/rpmsg-mat-mul_1.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "RPMsg examples: Matrix Multiplication demo"
 
 
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b30cbe0b980e98bfd9759b1e6ba3d107"
 
 SRC_URI = "\

--- a/recipes-openamp/rpmsg-examples/rpmsg-proxy-app_1.0.bb
+++ b/recipes-openamp/rpmsg-examples/rpmsg-proxy-app_1.0.bb
@@ -1,6 +1,6 @@
 SUMMARY = "RPMsg examples: Matrix Multiplication demo"
 
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b30cbe0b980e98bfd9759b1e6ba3d107"
 
 SRC_URI = "\


### PR DESCRIPTION
kirkstone does not allow plain BSD as a license name.
Fix this for the libraries and the examples