### PR TITLE
Various updates: Add Langdale support, bring forward current libmetal-xlnx version, and update rpmsg-mat-mul

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_openamp-layer = "5"
 # cause compatibility issues with other layers
 LAYERVERSION_openamp-layer = "1"
 
-LAYERSERIES_COMPAT_openamp-layer = "honister kirkstone"
+LAYERSERIES_COMPAT_openamp-layer = "honister kirkstone langdale"
 
 # set layer path for this layer only
 LAYER_PATH_openamp-layer = "${LAYERDIR}"

--- a/recipes-openamp/libmetal/libmetal-xlnx_v2022.2.bb
+++ b/recipes-openamp/libmetal/libmetal-xlnx_v2022.2.bb
@@ -1,0 +1,9 @@
+SRCBRANCH ?= "2022.2"
+SRCREV = "bee059dfedcfd98d1b113d8d6cce1c8aa916ff54"
+BRANCH = "xlnx_rel_v2022.2"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=1ff609e96fc79b87da48a837cbe5db33"
+PV = "${SRCBRANCH}+git${SRCPV}"
+
+REPO = "git://github.com/Xilinx/libmetal.git;protocol=https"
+
+include libmetal.inc

--- a/recipes-openamp/open-amp/open-amp-xlnx_v2022.2.bb
+++ b/recipes-openamp/open-amp/open-amp-xlnx_v2022.2.bb
@@ -1,0 +1,7 @@
+SRCBRANCH ?= "2022.2"
+SRCREV = "a6555a3d7b98741737c7d03b47567044cc5eb91e"
+BRANCH = "xlnx_rel_v2022.2"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=0e6d7bfe689fe5b0d0a89b2ccbe053fa"
+PV = "${SRCBRANCH}+git${SRCPV}"
+
+include open-amp.inc

--- a/recipes-openamp/rpmsg-examples/rpmsg-mat-mul/mat_mul_demo.c
+++ b/recipes-openamp/rpmsg-examples/rpmsg-mat-mul/mat_mul_demo.c
@@ -100,14 +100,11 @@ void matrix_mult(int ntimes)
 	}
 }
 
-/*
- * Probably an overkill to memset(.., sizeof(struct _matrix)) as
- * the firmware looks for SHUTDOWN_MSG in the first 32 bits.
- */
 void send_shutdown(int fd)
 {
-	memset(i_matrix, SHUTDOWN_MSG, sizeof(struct _matrix));
-	if (write(fd, i_matrix, sizeof(i_matrix)) < 0)
+	int sdm = SHUTDOWN_MSG;
+
+	if (write(fd, &sdm, sizeof(int)) < 0)
 		perror("write SHUTDOWN_MSG\n");
 }
 

--- a/vendor/xilinx/recipes-openamp/libmetal/libmetal_%.bbappend
+++ b/vendor/xilinx/recipes-openamp/libmetal/libmetal_%.bbappend
@@ -1,8 +1,5 @@
 LIBMETAL_MACHINE:versal = "zynqmp"
 
-SOC_FAMILY_ARCH ??= "${TUNE_PKGARCH}"
-PACKAGE_ARCH = "${SOC_FAMILY_ARCH}"
-
 EXTRA_OECMAKE:append:zynqmp = " -DWITH_VFIO=on"
 EXTRA_OECMAKE:append:versal = " -DWITH_VFIO=on"
 

--- a/vendor/xilinx/recipes-openamp/open-amp/open-amp_%.bbappend
+++ b/vendor/xilinx/recipes-openamp/open-amp/open-amp_%.bbappend
@@ -1,8 +1,5 @@
 OPENAMP_MACHINE:versal = "zynqmp"
 
-SOC_FAMILY_ARCH ??= "${TUNE_PKGARCH}"
-PACKAGE_ARCH = "${SOC_FAMILY_ARCH}"
-
 CFLAGS:append:versal = " -Dversal "
 
 # OpenAMP apps not ready for Zynq


### PR DESCRIPTION
This syncs up the latest Xilinx 2022.2 release elements into meta-openamp, as well as enabling 'langdale' support.  Langdale has been lightly tested but the main items I've tried do build and work.