### PR TITLE
vendor/xilinx open-amp-xlnx: Add switch for Versal_net

### DIFF
--- a/vendor/xilinx/recipes-openamp/open-amp/open-amp-xlnx.inc
+++ b/vendor/xilinx/recipes-openamp/open-amp/open-amp-xlnx.inc
@@ -1,6 +1,7 @@
 OPENAMP_MACHINE:versal = "zynqmp"
 
 CFLAGS:append:versal = " -Dversal "
+CFLAGS:append:versal-net = " -DVERSAL_NET "
 
 # OpenAMP apps not ready for Zynq
 EXTRA_OECMAKE:append:zynqmp = " -DWITH_APPS=ON"


### PR DESCRIPTION
Pass switch to OpenAMP repo so that it can configure for Versal_net as needed.