### PR TITLE
Declare support for YP 4.2 and 4.3

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,18 @@ BBFILE_PRIORITY_openamp-layer = "5"
 # cause compatibility issues with other layers
 LAYERVERSION_openamp-layer = "1"
 
-LAYERSERIES_COMPAT_openamp-layer = "honister kirkstone langdale"
+# meta-openamp upstream master branch supports:
+# = POLICY ======== CURRENT RELEASE ===
+# master            nanbield    YP 4.3 2023/10
+# latest release    mickledore  YP 4.2 2023/04
+# LTS               kirkstone   YP 4.0 2022/04
+#
+# Upstream also supports the following via the appropriate branch:
+# (LTS-1)           dunfell     YP 3.1 2020/04
+LAYERSERIES_COMPAT_openamp-layer = "kirkstone mickledore nanbield"
+
+# only for Xilinx petalinux
+LAYERSERIES_COMPAT_openamp-layer += "langdale"
 
 # set layer path for this layer only
 LAYER_PATH_openamp-layer = "${LAYERDIR}"

--- a/recipes-openamp/libmetal/libmetal_v2023.10.bb
+++ b/recipes-openamp/libmetal/libmetal_v2023.10.bb
@@ -1,6 +1,6 @@
-SRCBRANCH ?= "main"
 SRCREV = "0cb7d293a7f25394a06847a28d0f0ace9862936e"
 BRANCH = "v2023.10"
+SRCBRANCH ?= "${BRANCH}"
 PV = "${SRCBRANCH}+git${SRCPV}"
 
 include libmetal.inc

--- a/recipes-openamp/libmetal/libmetal_v2023.10.bb
+++ b/recipes-openamp/libmetal/libmetal_v2023.10.bb
@@ -1,0 +1,6 @@
+SRCBRANCH ?= "main"
+SRCREV = "0cb7d293a7f25394a06847a28d0f0ace9862936e"
+BRANCH = "v2023.10"
+PV = "${SRCBRANCH}+git${SRCPV}"
+
+include libmetal.inc

--- a/recipes-openamp/libmetal/libmetal_v2023.10.bb
+++ b/recipes-openamp/libmetal/libmetal_v2023.10.bb
@@ -2,5 +2,6 @@ SRCREV = "0cb7d293a7f25394a06847a28d0f0ace9862936e"
 BRANCH = "v2023.10"
 SRCBRANCH ?= "${BRANCH}"
 PV = "${SRCBRANCH}+git${SRCPV}"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=f4d5df0f12dcea1b1a0124219c0dbab4"
 
 include libmetal.inc

--- a/recipes-openamp/open-amp/open-amp_v2023.10.bb
+++ b/recipes-openamp/open-amp/open-amp_v2023.10.bb
@@ -1,6 +1,6 @@
-SRCBRANCH ?= "main"
 SRCREV = "1904dee18da85400e72b8f55c5c99e872a486573"
 BRANCH = "v2023.10"
+SRCBRANCH ?= "${BRANCH}"
 PV = "${SRCBRANCH}+git${SRCPV}"
 
 include open-amp.inc

--- a/recipes-openamp/open-amp/open-amp_v2023.10.bb
+++ b/recipes-openamp/open-amp/open-amp_v2023.10.bb
@@ -2,5 +2,6 @@ SRCREV = "1904dee18da85400e72b8f55c5c99e872a486573"
 BRANCH = "v2023.10"
 SRCBRANCH ?= "${BRANCH}"
 PV = "${SRCBRANCH}+git${SRCPV}"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=ab88daf995c0bd0071c2e1e55f3d3505"
 
 include open-amp.inc

--- a/recipes-openamp/open-amp/open-amp_v2023.10.bb
+++ b/recipes-openamp/open-amp/open-amp_v2023.10.bb
@@ -1,0 +1,6 @@
+SRCBRANCH ?= "main"
+SRCREV = "1904dee18da85400e72b8f55c5c99e872a486573"
+BRANCH = "v2023.10"
+PV = "${SRCBRANCH}+git${SRCPV}"
+
+include open-amp.inc

--- a/recipes-openamp/rpmsg-examples/rpmsg-example.inc
+++ b/recipes-openamp/rpmsg-examples/rpmsg-example.inc
@@ -5,12 +5,19 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE.md;md5=0b96a4c07d631aa5141bd3f058ba43b0"
 
 REPO = "git://github.com/OpenAMP/openamp-system-reference;protocol=https"
-BRANCH = "main"
 
-# this sets the default SRCREV for all rpmsg examples
-# you can set it in local.conf to "${AUTOREV}" to get the tip of main
-# This hash is tip of main as of 2023/2/6
-OPENAMP_SYS_REF_SRCREV ?= "7f1fb3b84edc1b3eab62a7ade7f88e99f7e78b93"
+# this sets the default SRCREV and BRANCH for all rpmsg examples
+# if you wish to use the tip of main set the following in local.conf
+# OPENAMP_SYS_REF_SRCREV="${AUTOREV}"
+# OPENAMP_SYS_REF_BRANCH="main"
+#
+# These values select the commit tagged by v2023.10.0
+OPENAMP_SYS_REF_SRCREV ?= "3716dbba0154259d5efa3fa359313cce69cd163d"
+OPENAMP_SYS_REF_BRANCH ?= "v2023.10"
+
+# This include is used by multiple recipes
+# now set the variables for this recipe
+BRANCH  = "${OPENAMP_SYS_REF_BRANCH}"
+SRCREV  = "${OPENAMP_SYS_REF_SRCREV}"
 
 SRC_URI = "${REPO};branch=${BRANCH};"
-SRCREV  = "${OPENAMP_SYS_REF_SRCREV}"

--- a/recipes-openamp/rpmsg-examples/rpmsg-utils_1.0.bb
+++ b/recipes-openamp/rpmsg-examples/rpmsg-utils_1.0.bb
@@ -1,0 +1,21 @@
+SUMMARY = "RPMsg utilities: utilities for /dev/rpmsg*"
+
+include rpmsg-example.inc
+
+S = "${WORKDIR}/git/examples/linux/rpmsg-utils"
+
+RRECOMMENDS:${PN} = "kernel-module-rpmsg-char"
+
+FILES:${PN} = "\
+	/usr/bin/rpmsg_destroy_ept \
+	/usr/bin/rpmsg_export_dev \
+	/usr/bin/rpmsg_export_ept \
+	/usr/bin/rpmsg_ping \
+"
+
+EXTRA_OEMAKE = "DESTDIR=${D} prefix=/usr CC='${CC}' CFLAGS='${CFLAGS}' LDFLAGS='${LDFLAGS}'"
+
+do_install() {
+	install -d ${D}/usr/bin
+	oe_runmake install
+}


### PR DESCRIPTION
* Set the default policy for the master branch
* update for current release names for 2023/09
* Keep the Xilinx specific EOL releases for now