### PR TITLE
Add rpmsg_utils: User space utilities to exercise /dev/rpmsg*

### DIFF
--- a/recipes-openamp/rpmsg-examples/rpmsg-utils_1.0.bb
+++ b/recipes-openamp/rpmsg-examples/rpmsg-utils_1.0.bb
@@ -1,0 +1,21 @@
+SUMMARY = "RPMsg utilities: utilities for /dev/rpmsg*"
+
+include rpmsg-example.inc
+
+S = "${WORKDIR}/git/examples/linux/rpmsg-utils"
+
+RRECOMMENDS:${PN} = "kernel-module-rpmsg-ctrl kernel-module-rpmsg-char"
+
+FILES:${PN} = "\
+	/usr/bin/rpmsg_destroy_ept \
+	/usr/bin/rpmsg_export_dev \
+	/usr/bin/rpmsg_export_ept \
+	/usr/bin/rpmsg_ping \
+"
+
+EXTRA_OEMAKE = "DESTDIR=${D} prefix=/usr CC='${CC}' CFLAGS='${CFLAGS}' LDFLAGS='${LDFLAGS}'"
+
+do_install() {
+	install -d ${D}/usr/bin
+	oe_runmake install
+}


### PR DESCRIPTION
This set of utilities has existed for over a year but have not been built or packaged in OE until now.

These utilities are in the same git rep as the other examples. Rev them as a group and reuse the inc file.