### PR TITLE
Add Xilinx 2023.1 and 2023.2 to the vendor directory

### DIFF
--- a/vendor/xilinx/meta-xilinx-standalone-experimental/recipes-openamp/open-amp/open-amp-xlnx.inc
+++ b/vendor/xilinx/meta-xilinx-standalone-experimental/recipes-openamp/open-amp/open-amp-xlnx.inc
@@ -27,7 +27,7 @@ OPENAMP_OVERLAY ?= "${OPENAMP_OVERLAY_DEFAULT}"
 SRC_URI:append = "  file://${OPENAMP_OVERLAY} "
 
 OECMAKE_C_LINK_FLAGS:xilinx-standalone:append = " --sysroot=${STAGING_DIR_HOST} "
-CFLAGS:append = " -DSDT -D_AMD_GENERATED_ "
+CFLAGS:append = " -DSDT -D_AMD_GENERATED_ ${DEBUG_PREFIX_MAP} "
 CFLAGS:xilinx-standalone:append = " -O3  -DXLNX_PLATFORM \
  -specs=${PKG_CONFIG_SYSROOT_DIR}/usr/include/Xilinx.spec \
  "

--- a/vendor/xilinx/recipes-openamp/libmetal/libmetal-xlnx_v2023.1.bb
+++ b/vendor/xilinx/recipes-openamp/libmetal/libmetal-xlnx_v2023.1.bb
@@ -1,0 +1,19 @@
+SRCBRANCH ?= "2023.1"
+SRCREV = "be635252271de342014a146825870b64bd41d6eb"
+BRANCH = "xlnx_rel_v2023.1"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=f4d5df0f12dcea1b1a0124219c0dbab4"
+PV = "${SRCBRANCH}+git${SRCPV}"
+
+REPO = "git://github.com/Xilinx/libmetal.git;protocol=https"
+
+include ${LAYER_PATH_openamp-layer}/recipes-openamp/libmetal/libmetal.inc
+
+EXTRA_OECMAKE += " \
+       -DSOC_FAMILY="${SOC_FAMILY}" \
+"
+
+RPROVIDES:${PN}-dbg += "libmetal-dbg"
+RPROVIDES:${PN}-dev += "libmetal-dev"
+RPROVIDES:${PN}-lic += "libmetal-lic"
+RPROVIDES:${PN}-src += "libmetal-src"
+RPROVIDES:${PN}-staticdev += "libmetal-staticdev"

--- a/vendor/xilinx/recipes-openamp/libmetal/libmetal-xlnx_v2023.2.bb
+++ b/vendor/xilinx/recipes-openamp/libmetal/libmetal-xlnx_v2023.2.bb
@@ -1,0 +1,19 @@
+SRCBRANCH ?= "2023.2"
+SRCREV = "00fd771adc7adaed664ed6c5bc3d48d25856fe5c"
+BRANCH = "xlnx_rel_v2023.2"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=f4d5df0f12dcea1b1a0124219c0dbab4"
+PV = "${SRCBRANCH}+git${SRCPV}"
+
+REPO = "git://github.com/Xilinx/libmetal.git;protocol=https"
+
+include ${LAYER_PATH_openamp-layer}/recipes-openamp/libmetal/libmetal.inc
+
+EXTRA_OECMAKE += " \
+       -DSOC_FAMILY="${SOC_FAMILY}" \
+"
+
+RPROVIDES:${PN}-dbg += "libmetal-dbg"
+RPROVIDES:${PN}-dev += "libmetal-dev"
+RPROVIDES:${PN}-lic += "libmetal-lic"
+RPROVIDES:${PN}-src += "libmetal-src"
+RPROVIDES:${PN}-staticdev += "libmetal-staticdev"

--- a/vendor/xilinx/recipes-openamp/open-amp/open-amp-xlnx_v2023.1.bb
+++ b/vendor/xilinx/recipes-openamp/open-amp/open-amp-xlnx_v2023.1.bb
@@ -1,0 +1,16 @@
+SRCBRANCH ?= "2023.1"
+SRCREV = "c8aaf2f26d5493f492f0af09dd558d45908636da"
+BRANCH = "xlnx_rel_v2023.1"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=ab88daf995c0bd0071c2e1e55f3d3505"
+PV = "${SRCBRANCH}+git${SRCPV}"
+REPO = "git://github.com/Xilinx/open-amp.git;protocol=https"
+
+include ${LAYER_PATH_openamp-layer}/recipes-openamp/open-amp/open-amp.inc
+require ${LAYER_PATH_openamp-layer}/vendor/xilinx/recipes-openamp/open-amp/open-amp-xlnx.inc
+
+RPROVIDES:${PN}-dbg += "open-amp-dbg"
+RPROVIDES:${PN}-dev += "open-amp-dev"
+RPROVIDES:${PN}-lic += "open-amp-lic"
+RPROVIDES:${PN}-src += "open-amp-src"
+RPROVIDES:${PN}-staticdev += "open-amp-staticdev"
+

--- a/vendor/xilinx/recipes-openamp/open-amp/open-amp-xlnx_v2023.2.bb
+++ b/vendor/xilinx/recipes-openamp/open-amp/open-amp-xlnx_v2023.2.bb
@@ -1,0 +1,16 @@
+SRCBRANCH ?= "2023.2"
+SRCREV = "73a546f2b5faffe71680b1e5389f3328be60773f"
+BRANCH = "xlnx_rel_v2023.2"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=ab88daf995c0bd0071c2e1e55f3d3505"
+PV = "${SRCBRANCH}+git${SRCPV}"
+REPO = "git://github.com/Xilinx/open-amp.git;protocol=https"
+
+include ${LAYER_PATH_openamp-layer}/recipes-openamp/open-amp/open-amp.inc
+require ${LAYER_PATH_openamp-layer}/vendor/xilinx/recipes-openamp/open-amp/open-amp-xlnx.inc
+
+RPROVIDES:${PN}-dbg += "open-amp-dbg"
+RPROVIDES:${PN}-dev += "open-amp-dev"
+RPROVIDES:${PN}-lic += "open-amp-lic"
+RPROVIDES:${PN}-src += "open-amp-src"
+RPROVIDES:${PN}-staticdev += "open-amp-staticdev"
+


### PR DESCRIPTION
Add Xilinx 2023.1 and 2023.2 to the vendor directory.  Also fix a minor bug related to TMPDIR references.