### PR TITLE
Update to v2024.05 for libmetal, open-amp, rpmsg examples, and rpmsg utils

### DIFF
--- a/recipes-openamp/libmetal/libmetal_v2024.05.bb
+++ b/recipes-openamp/libmetal/libmetal_v2024.05.bb
@@ -1,0 +1,8 @@
+# SRVREV == v2024.05.0
+SRCREV = "3aee6be866b190d2e2b4997fedbd976a0c37c0c6"
+BRANCH = "v2024.05"
+SRCBRANCH ?= "${BRANCH}"
+PV = "${SRCBRANCH}+git${SRCPV}"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=f4d5df0f12dcea1b1a0124219c0dbab4"
+
+include libmetal.inc

--- a/recipes-openamp/open-amp/open-amp_v2024.05.bb
+++ b/recipes-openamp/open-amp/open-amp_v2024.05.bb
@@ -1,0 +1,8 @@
+# SRCREV == v2024.05.1
+SRCREV = "856680eb99cee67dfff3d2e9c6d4ede3b7549895"
+BRANCH = "v2024.05"
+SRCBRANCH ?= "${BRANCH}"
+PV = "${SRCBRANCH}+git${SRCPV}"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=ab88daf995c0bd0071c2e1e55f3d3505"
+
+include open-amp.inc

--- a/recipes-openamp/rpmsg-examples/rpmsg-example.inc
+++ b/recipes-openamp/rpmsg-examples/rpmsg-example.inc
@@ -12,8 +12,8 @@ REPO = "git://github.com/OpenAMP/openamp-system-reference;protocol=https"
 # OPENAMP_SYS_REF_BRANCH="main"
 #
 # These values select the commit tagged by v2023.10.0
-OPENAMP_SYS_REF_SRCREV ?= "2c5d2064e45faf7e3a542d1232593beec40ff940"
-OPENAMP_SYS_REF_BRANCH ?= "v2023.10"
+OPENAMP_SYS_REF_SRCREV ?= "aa4163be7f4386fb49635d68b920072efc7e5f26"
+OPENAMP_SYS_REF_BRANCH ?= "v2024.05"
 
 # This include is used by multiple recipes
 # now set the variables for this recipe


### PR DESCRIPTION
* Create v2024.05 recipes for libmetal and open-amp.
* Update rpmsg-utls and examples to use the v2024.05 branch and commit id

This PR is required for the v2024.05 OpenAMP release.
(OpenAMP releases are named from the date of the library tag even if the demo builds and images are done later.)