### PR TITLE
linux: add genericarm64 as an alias for generic-arm64 machine

### DIFF
--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -6,5 +6,6 @@ KERNEL_FEATURES:append = "${@bb.utils.contains('DISTRO_FEATURES', 'openamp', ' c
 # genericarm64 via qemuarm64 w/ openamp distro feature
 KERNEL_FEATURES:qemuarm64:append = "${@bb.utils.contains('DISTRO_FEATURES', 'openamp', ' cfg/remoteproc-generic-arm64.scc', '', d)}"
 KERNEL_FEATURES:generic-arm64:append = "${@bb.utils.contains('DISTRO_FEATURES', 'openamp', ' cfg/remoteproc-generic-arm64.scc', '', d)}"
+KERNEL_FEATURES:genericarm64:append = "${@bb.utils.contains('DISTRO_FEATURES', 'openamp', ' cfg/remoteproc-generic-arm64.scc', '', d)}"
 KERNEL_FEATURES:qemuarm:append = "${@bb.utils.contains('DISTRO_FEATURES', 'openamp', ' cfg/remoteproc-generic-armv7a.scc', '', d)}"
 KERNEL_FEATURES:generic-armv7a:append = "${@bb.utils.contains('DISTRO_FEATURES', 'openamp', ' cfg/remoteproc-generic-armv7a.scc', '', d)}"


### PR DESCRIPTION
For scarthgap (5.0 2024/04) and later, generic-arm64 has moved from meta-arm to poky/meta-yocto-bsp and dropped the dash.

Keep both for now as we want master to be compatible with kirkstone.

Note:  This PR is required for the OpenAMP v2024.05 release.