### PR TITLE
Adjust openamp-image-minimal to include rpmsg utilities and clean up recipe

### DIFF
--- a/recipes-openamp/images/openamp-image-minimal.bb
+++ b/recipes-openamp/images/openamp-image-minimal.bb
@@ -13,8 +13,4 @@ IMAGE_INSTALL:append = " \
     rpmsg-echo-test rpmsg-mat-mul rpmsg-proxy-app rpmsg-utils \
     "
 
-# for the generic arm64 machine (right now qemuarm64)
-# install all the modules we built
-IMAGE_INSTALL:qemuarm64:append = " kernel-modules"
-
 IMAGE_LINGUAS=""

--- a/recipes-openamp/images/openamp-image-minimal.bb
+++ b/recipes-openamp/images/openamp-image-minimal.bb
@@ -10,6 +10,7 @@ IMAGE_INSTALL:append = " \
     ${CORE_IMAGE_EXTRA_INSTALL} \
     libmetal \
     open-amp \
+    rpmsg-echo-test rpmsg-mat-mul rpmsg-proxy-app rpmsg-utils \
     "
 
 # for the generic arm64 machine (right now qemuarm64)


### PR DESCRIPTION
The openamp-image-minimal is not a lot different than core-image-minimal except it includes the Linux user space version of the libmetal and open-amp libraries.  It should also include the rpmsg examples and utilities otherwise it is pretty useless.

Also get rid of the modification for qemuarm64.  This was a left over from when we used qemuarm64 as a standing for genericarm64.  This is not needed anymore as we have genericarm64 in 5.0+ and we had generic-arm64 from meta-arm before that.