### PR TITLE
Update open-amp licence md5sum

### DIFF
--- a/recipes-openamp/open-amp/open-amp-dev_git.bb
+++ b/recipes-openamp/open-amp/open-amp-dev_git.bb
@@ -3,6 +3,6 @@ SRCREV = "${@oe.utils.conditional("PREFERRED_PROVIDER_open-amp", "open-amp-dev",
 BRANCH = "main"
 PV = "${SRCBRANCH}+git${SRCPV}"
 DEFAULT_PREFERENCE = "-1"
-LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=ab88daf995c0bd0071c2e1e55f3d3505"
+LIC_FILES_CHKSUM ?= "file://LICENSE.md;md5=dfc0adf4d04cc738ba65b7d3f587dca5"
 
 include open-amp.inc


### PR DESCRIPTION
The LICENSE.md file was changed after v2024.05.
This PR is required for CI to build from master