### PR TITLE
add usrmerge insane skip rule to R5 firmware example

### DIFF
--- a/vendor/xilinx/meta-xilinx-standalone-experimental/recipes-openamp/open-amp/open-amp-firmware.bb
+++ b/vendor/xilinx/meta-xilinx-standalone-experimental/recipes-openamp/open-amp/open-amp-firmware.bb
@@ -3,7 +3,7 @@ SECTION = "PETALINUX/apps"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-INSANE_SKIP:${PN} = "arch"
+INSANE_SKIP:${PN} = "arch usrmerge"
 
 
 


### PR DESCRIPTION
Hi!

i was using a modified copy of the `open-amp-firmware.bb` example recipe to include a given R5 binary into my Yocto build.
It didn't work because of a QA check which does not allow files placed in `/lib/firmware`.

So, i added `usrmerge` to the `INSANE_SKIP` variable of the recipe to suppress that error.
